### PR TITLE
Enables snippet drag-and-drop reordering

### DIFF
--- a/AutoTyper.UI/AutoTyper.UI.csproj
+++ b/AutoTyper.UI/AutoTyper.UI.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="gong-wpf-dragdrop" />
     <PackageReference Include="Henooh.DeviceEmulator">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/AutoTyper.UI/MainWindow.xaml
+++ b/AutoTyper.UI/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:models="clr-namespace:AutoTyper.UI.Models"
         xmlns:viewModels="clr-namespace:AutoTyper.UI.ViewModels"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:dd="urn:gong-wpf-dragdrop"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=local:MainWindowViewModel, IsDesignTimeCreatable=False}"
         Style="{StaticResource MaterialDesignWindow}"
@@ -181,7 +182,10 @@
       <ScrollViewer Grid.Row="2" 
                          VerticalScrollBarVisibility="Auto"
                          Margin="16">
-        <ItemsControl ItemsSource="{Binding Snippets}">
+        <ItemsControl ItemsSource="{Binding Snippets}"
+                      dd:DragDrop.IsDragSource="True"
+                      dd:DragDrop.IsDropTarget="True"
+                      dd:DragDrop.DropHandler="{Binding}">
           <ItemsControl.ItemTemplate>
             <DataTemplate DataType="{x:Type models:Snippet}">
               <materialDesign:Card Margin="0,0,0,12"

--- a/AutoTyper.UI/Models/Snippet.cs
+++ b/AutoTyper.UI/Models/Snippet.cs
@@ -18,4 +18,7 @@ public partial class Snippet : ObservableObject
 
     [ObservableProperty]
     private bool _appendNewLine;
+
+    [ObservableProperty]
+    private int _order;
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="gong-wpf-dragdrop" Version="3.2.1" />
     <PackageVersion Include="Henooh.DeviceEmulator" Version="1.1.8" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />


### PR DESCRIPTION
Introduces functionality for users to reorder snippets directly within the main window. This improves user experience by allowing intuitive management of snippet sequence.

The implementation involves:
- Integrating the `gong-wpf-dragdrop` library for handling drag-and-drop UI interactions.
- Adding an `Order` property to the `Snippet` model to track and persist the position of each snippet.
- Updating the main view model to implement the `IDropTarget` interface, which handles drag and drop events and automatically saves the updated order.