### PR TITLE
Adds snippet view mode selection

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Push Release
         if: github.event_name == 'workflow_dispatch'
-        run: dotnet vpk publish -o .\publish --waitForLive --api-key ${{ secrets.VPK_API_KEY }}
+        run: dotnet vpk publish -o .\Releases --waitForLive --api-key ${{ secrets.VPK_API_KEY }}
 
   automerge:
     if: ${{ github.event_name == 'pull_request' }}

--- a/AutoTyper.UI.Tests/MainWindowViewModelTests.cs
+++ b/AutoTyper.UI.Tests/MainWindowViewModelTests.cs
@@ -15,7 +15,7 @@ public partial class MainWindowViewModelTests
         AutoMocker mocker = new();
         mocker.GetMock<SnippetStorageService>()
             .Setup(x => x.LoadSnippetsAsync())
-            .ReturnsAsync(new List<Snippet>());
+            .ReturnsAsync([]);
 
         mocker.GetMock<ThemeService>()
             .Setup(x => x.IsDarkMode)
@@ -58,7 +58,7 @@ public partial class MainWindowViewModelTests
 
         mocker.GetMock<SnippetStorageService>()
             .Setup(x => x.LoadSnippetsAsync())
-            .ReturnsAsync(new List<Snippet> { testSnippet });
+            .ReturnsAsync([testSnippet]);
 
         mocker.GetMock<ThemeService>()
             .Setup(x => x.IsDarkMode)
@@ -86,7 +86,7 @@ public partial class MainWindowViewModelTests
         AutoMocker mocker = new();
         mocker.GetMock<SnippetStorageService>()
             .Setup(x => x.LoadSnippetsAsync())
-            .ReturnsAsync(new List<Snippet>());
+            .ReturnsAsync([]);
 
         mocker.GetMock<ThemeService>()
             .Setup(x => x.IsDarkMode)

--- a/AutoTyper.UI/App.xaml
+++ b/AutoTyper.UI/App.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AutoTyper.UI"
+             xmlns:converters="clr-namespace:AutoTyper.UI.Converters"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
   <Application.Resources>
     <ResourceDictionary>
@@ -17,6 +18,7 @@
       </ResourceDictionary.MergedDictionaries>
 
       <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+      <converters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </ResourceDictionary>
   </Application.Resources>
 </Application>

--- a/AutoTyper.UI/Converters/EnumToBooleanConverter.cs
+++ b/AutoTyper.UI/Converters/EnumToBooleanConverter.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace AutoTyper.UI.Converters;
+
+public class EnumToBooleanConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+            return false;
+
+        return value.Equals(parameter);
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool boolValue && boolValue && parameter != null)
+            return parameter;
+
+        return Binding.DoNothing;
+    }
+}

--- a/AutoTyper.UI/MainWindow.xaml
+++ b/AutoTyper.UI/MainWindow.xaml
@@ -125,6 +125,26 @@
               <materialDesign:PackIcon Kind="Pin"/>
             </MenuItem.Icon>
           </MenuItem>
+          <Separator/>
+          <MenuItem Header="_Full View" 
+                              IsCheckable="True"
+                              IsChecked="{Binding CurrentViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter={x:Static local:ViewMode.Full}}"
+                              Command="{Binding SetViewModeCommand}"
+                              CommandParameter="{x:Static local:ViewMode.Full}">
+            <MenuItem.Icon>
+              <materialDesign:PackIcon Kind="ViewList"/>
+            </MenuItem.Icon>
+          </MenuItem>
+          <MenuItem Header="_Compact View" 
+                              IsCheckable="True"
+                              IsChecked="{Binding CurrentViewMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter={x:Static local:ViewMode.Compact}}"
+                              Command="{Binding SetViewModeCommand}"
+                              CommandParameter="{x:Static local:ViewMode.Compact}">
+            <MenuItem.Icon>
+              <materialDesign:PackIcon Kind="ViewHeadline"/>
+            </MenuItem.Icon>
+          </MenuItem>
+          <Separator/>
           <MenuItem Header="_Dark Mode" 
                               IsCheckable="True"
                               IsChecked="{Binding IsDarkMode}"
@@ -211,51 +231,124 @@
                         <RowDefinition Height="Auto"/>
                       </Grid.RowDefinitions>
 
-                      <!-- Name -->
-                      <TextBlock Grid.Row="0"
-                                Text="{Binding Name}"
-                                FontSize="16"
-                                FontWeight="SemiBold"
-                                Margin="0,0,0,4"/>
+                      <!-- Full View Layout -->
+                      <Grid Grid.Row="0" Grid.RowSpan="3">
+                        <Grid.Style>
+                          <Style TargetType="Grid">
+                            <Setter Property="Visibility" Value="Visible"/>
+                            <Style.Triggers>
+                              <DataTrigger Binding="{Binding DataContext.CurrentViewMode, RelativeSource={RelativeSource AncestorType=Window}}" 
+                                           Value="{x:Static local:ViewMode.Compact}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                              </DataTrigger>
+                            </Style.Triggers>
+                          </Style>
+                        </Grid.Style>
+                        
+                        <Grid.RowDefinitions>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                          <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-                      <!-- Content Preview -->
-                      <TextBlock Grid.Row="1"
-                                  Text="{Binding Content}"
-                                  TextWrapping="NoWrap"
-                                  TextTrimming="CharacterEllipsis"
-                                  Opacity="0.7"
-                                  Margin="0,0,0,8"/>
+                        <!-- Name -->
+                        <TextBlock Grid.Row="0"
+                                  Text="{Binding Name}"
+                                  FontSize="16"
+                                  FontWeight="SemiBold"
+                                  Margin="0,0,0,4"/>
 
-                      <!-- Properties -->
-                      <StackPanel Grid.Row="2" Orientation="Horizontal">
-                        <materialDesign:Chip Content="{Binding Delay, StringFormat='{}{0}s delay'}"
-                                            Margin="0,0,8,0"
-                                            IconBackground="{DynamicResource PrimaryHueMidBrush}"
-                                            IconForeground="{DynamicResource PrimaryHueMidForegroundBrush}">
-                          <materialDesign:Chip.Icon>
-                            <materialDesign:PackIcon Kind="ClockOutline"/>
-                          </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
+                        <!-- Content Preview -->
+                        <TextBlock Grid.Row="1"
+                                    Text="{Binding Content}"
+                                    TextWrapping="NoWrap"
+                                    TextTrimming="CharacterEllipsis"
+                                    Opacity="0.7"
+                                    Margin="0,0,0,8"/>
 
-                        <materialDesign:Chip Content="Fast Typing"
+                        <!-- Properties -->
+                        <StackPanel Grid.Row="2" Orientation="Horizontal">
+                          <materialDesign:Chip Content="{Binding Delay, StringFormat='{}{0}s delay'}"
                                               Margin="0,0,8,0"
-                                              Visibility="{Binding FastTyping, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                              IconBackground="{DynamicResource SecondaryHueMidBrush}"
-                                              IconForeground="{DynamicResource SecondaryHueMidForegroundBrush}">
-                          <materialDesign:Chip.Icon>
-                            <materialDesign:PackIcon Kind="FlashOutline"/>
-                          </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
+                                              IconBackground="{DynamicResource PrimaryHueMidBrush}"
+                                              IconForeground="{DynamicResource PrimaryHueMidForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="ClockOutline"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
 
-                        <materialDesign:Chip Content="+ Enter"
-                                            Visibility="{Binding AppendNewLine, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                            IconBackground="{DynamicResource PrimaryHueLightBrush}"
-                                            IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}">
-                          <materialDesign:Chip.Icon>
-                            <materialDesign:PackIcon Kind="KeyboardReturn"/>
-                          </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
-                      </StackPanel>
+                          <materialDesign:Chip Content="Fast Typing"
+                                                Margin="0,0,8,0"
+                                                Visibility="{Binding FastTyping, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                IconBackground="{DynamicResource SecondaryHueMidBrush}"
+                                                IconForeground="{DynamicResource SecondaryHueMidForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="FlashOutline"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
+
+                          <materialDesign:Chip Content="+ Enter"
+                                              Visibility="{Binding AppendNewLine, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                              IconBackground="{DynamicResource PrimaryHueLightBrush}"
+                                              IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="KeyboardReturn"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
+                        </StackPanel>
+                      </Grid>
+
+                      <!-- Compact View Layout -->
+                      <DockPanel Grid.Row="0" Grid.RowSpan="3">
+                        <DockPanel.Style>
+                          <Style TargetType="DockPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                              <DataTrigger Binding="{Binding DataContext.CurrentViewMode, RelativeSource={RelativeSource AncestorType=Window}}" 
+                                           Value="{x:Static local:ViewMode.Compact}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                              </DataTrigger>
+                            </Style.Triggers>
+                          </Style>
+                        </DockPanel.Style>
+
+                        <!-- Chips on the right -->
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="16,0,0,0">
+                          <materialDesign:Chip Content="{Binding Delay, StringFormat='{}{0}s'}"
+                                              Margin="0,0,4,0"
+                                              IconBackground="{DynamicResource PrimaryHueMidBrush}"
+                                              IconForeground="{DynamicResource PrimaryHueMidForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="ClockOutline"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
+
+                          <materialDesign:Chip Content="Fast"
+                                                Margin="0,0,4,0"
+                                                Visibility="{Binding FastTyping, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                IconBackground="{DynamicResource SecondaryHueMidBrush}"
+                                                IconForeground="{DynamicResource SecondaryHueMidForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="FlashOutline"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
+
+                          <materialDesign:Chip Content="↵"
+                                              Visibility="{Binding AppendNewLine, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                              IconBackground="{DynamicResource PrimaryHueLightBrush}"
+                                              IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}">
+                            <materialDesign:Chip.Icon>
+                              <materialDesign:PackIcon Kind="KeyboardReturn"/>
+                            </materialDesign:Chip.Icon>
+                          </materialDesign:Chip>
+                        </StackPanel>
+
+                        <!-- Name on the left -->
+                        <TextBlock Text="{Binding Name}"
+                                  FontSize="16"
+                                  FontWeight="SemiBold"
+                                  VerticalAlignment="Center"/>
+                      </DockPanel>
                     </Grid>
                   </Button>
 

--- a/AutoTyper.UI/MainWindowViewModel.cs
+++ b/AutoTyper.UI/MainWindowViewModel.cs
@@ -20,6 +20,12 @@ public enum DialogResult
     Confirmed,
 }
 
+public enum ViewMode
+{
+    Full,
+    Compact
+}
+
 public partial class MainWindowViewModel : ObservableObject, IDropTarget
 {
     private readonly SnippetStorageService _storageService;
@@ -31,6 +37,9 @@ public partial class MainWindowViewModel : ObservableObject, IDropTarget
 
     [ObservableProperty]
     private bool _isDarkMode;
+
+    [ObservableProperty]
+    private ViewMode _currentViewMode = ViewMode.Full;
 
     public ObservableCollection<Snippet> Snippets { get; } = [];
 
@@ -215,6 +224,12 @@ public partial class MainWindowViewModel : ObservableObject, IDropTarget
         _themeService.ToggleTheme();
         IsDarkMode = _themeService.IsDarkMode;
         StatusMessage = $"Switched to {(IsDarkMode ? "dark" : "light")} mode";
+    }
+
+    [RelayCommand]
+    private void SetViewMode(ViewMode mode)
+    {
+        CurrentViewMode = mode;
     }
 
     // IDropTarget implementation for drag-drop reordering


### PR DESCRIPTION
Introduces the ability to switch between "Full" and "Compact" views for snippets, improving layout flexibility.

*   **View Mode Functionality**: Users can now select their preferred snippet display mode from the "View" menu.
    *   **Full View**: Displays all snippet details including name, content preview, delay, fast typing, and new line indicators.
    *   **Compact View**: Shows a concise layout with the snippet name and essential properties (delay, fast typing, new line) presented as chips.
*   **Implementation Details**:
    *   A new `ViewMode` enum and an `ObservableProperty` in the ViewModel manage the active view.
    *   An `EnumToBooleanConverter` facilitates binding menu item checked states to the `ViewMode` enum.
    *   The UI dynamically switches between different layouts for snippet presentation based on the selected view mode.
*   **Workflow Update**: Updates the GitHub Actions workflow to publish VPK packages to a dedicated `Releases` directory.
*   **Test Code Refinement**: Improves test code readability by using C# 9.0 target-typed `new` expressions for collections.